### PR TITLE
Fix Flutter 3.27+ compatibility: replace isAlwaysShown with thumbVisibility

### DIFF
--- a/lib/src/bootstrap_select.dart
+++ b/lib/src/bootstrap_select.dart
@@ -115,7 +115,7 @@ class _BootstrapMultiSelectState extends State<BootstrapMultiSelect> {
         width: double.infinity,
         padding: const EdgeInsets.only(left: 10, top: 5, right: 5, bottom: 5),
         child: Scrollbar(
-          isAlwaysShown: true,
+          thumbVisibility: true,
           controller: _scrollController,
           child: ListView.builder(
             controller: _scrollController,


### PR DESCRIPTION
## Summary
Fixed compilation error that occurs when building with Flutter 3.27+ by replacing the deprecated `isAlwaysShown` parameter with `thumbVisibility`.

## Problem
The `isAlwaysShown` parameter was deprecated in Flutter 3.x and causes compilation failures:
```
Error: No named parameter with the name 'isAlwaysShown'.
          isAlwaysShown: true,
          ^^^^^^^^^^^^^
```

## Solution
- Replace `isAlwaysShown: true` with `thumbVisibility: true` in `bootstrap_select.dart`
- This maintains the same functionality while using the current Flutter API

## Testing
- ✅ Successfully builds with Flutter 3.27.4
- ✅ Maintains existing functionality
- ✅ No breaking changes to the public API

This fix resolves deployment issues in CI/CD environments using modern Flutter versions.

🤖 Generated with [Claude Code](https://claude.ai/code)